### PR TITLE
Fix SmolVLM model loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ git+https://github.com/dbklim/RNNoise_Wrapper.git@master#egg=rnnoise_wrapper
 nltk
 cv2
 pydantic<2
-transformers
+transformers>=4.40

--- a/video-fixer/processing/llm.py
+++ b/video-fixer/processing/llm.py
@@ -10,9 +10,9 @@ import torch
 try:  # transformers < 4.40 may not expose AutoModelForConditionalGeneration
     from transformers import AutoProcessor, AutoModelForConditionalGeneration
 except ImportError:  # pragma: no cover - fallback for older versions
-    from transformers import (
-        AutoProcessor,
-        AutoModelForCausalLM as AutoModelForConditionalGeneration,
+    raise ImportError(
+        "Transformers >= 4.40 is required to run the SmolVLM model. "
+        "Please upgrade the 'transformers' package."
     )
 
 # Pull your HF token from the environment


### PR DESCRIPTION
## Summary
- require transformers >=4.40 to support SmolVLM
- update model loader to raise helpful error when the library is too old

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`