### PR TITLE
Add helper script for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ PY
 python app.py  # => http://127.0.0.1:7860
 ```
 
+### Using the helper script
+
+If you'd like to automate these steps, simply run:
+
+```bash
+./run_app.sh
+```
+The script creates the virtual environment, installs requirements, downloads the
+models on first run and launches the app for you.
+
 Docker users:
 
 ```bash

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Simple setup script to run the AI Video Fixer locally.
+# Creates a virtual environment, installs dependencies,
+# downloads lightweight model checkpoints on first run and
+# launches the Gradio app.
+set -e
+
+# Determine repo root (directory of this script)
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# 1. Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+# 2. Install Python requirements
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# 3. Download required models (run once)
+python - <<'PY'
+from demucs.pretrained import get_model
+get_model('htdemucs_light')
+from faster_whisper import WhisperModel
+WhisperModel('tiny-int8', download_root='./models')
+PY
+
+# 4. Launch the application
+python video-fixer/app.py


### PR DESCRIPTION
## Summary
- add `run_app.sh` to automate setup and startup
- document script usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b91c152c832f928b6a4ab8bff947